### PR TITLE
Fix tests and config path

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,4 +41,4 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: vendor/bin/phpunit
+        run: vendor/bin/phpunit tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,4 +41,4 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: vendor/bin/phpunit tests/
+        run: vendor/bin/phpunit

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Feature">
+      <directory suffix="Test.php">./tests/Feature</directory>
+    </testsuite>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/src/Providers/SupportTicketServiceProvider.php
+++ b/src/Providers/SupportTicketServiceProvider.php
@@ -62,9 +62,9 @@ class SupportTicketServiceProvider extends ServiceProvider
     protected function registerConfig(): void
     {
         $this->publishes([
-            __DIR__ . '/../config/config.php' => config_path('support-ticket.php'),
+            __DIR__ . '/../../config/config.php' => config_path('support-ticket.php'),
         ], 'support-ticket-config');
-        $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'support-ticket');
+        $this->mergeConfigFrom(__DIR__ . '/../../config/config.php', 'support-ticket');
     }
 
     protected function registerTranslations(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -91,7 +91,7 @@ abstract class TestCase extends Orchestra
     {
         return [
             CoreServiceProvider::class,
-            \$MODULE_NAMESPACE$\SupportTicket\Providers\SupportTicketServiceProvider::class,
+            \Juzaweb\Modules\SupportTicket\Providers\SupportTicketServiceProvider::class,
             \Juzaweb\QueryCache\QueryCacheServiceProvider::class,
             \Spatie\Activitylog\ActivitylogServiceProvider::class,
             \Juzaweb\Hooks\HooksServiceProvider::class,

--- a/tests/themes/itech/theme.json
+++ b/tests/themes/itech/theme.json
@@ -1,0 +1,1 @@
+{"name":"itech","title":"Itech Theme","version":"1.0","require":[]}


### PR DESCRIPTION
Fixes an issue where `phpunit` tests failed to run due to a syntax error in the test namespace and incorrect config path in the service provider.

---
*PR created automatically by Jules for task [2280612777426693639](https://jules.google.com/task/2280612777426693639) started by @juzaweb*