### PR TITLE
Add Support Ticket API endpoints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "juzaweb/core": "^5.0"
     },
     "require-dev": {
-        "juzaweb/api": "dev-master",
+        "juzaweb/api": "^1.0",
         "orchestra/testbench": "^8.0|^9.0",
         "phpunit/phpunit": "^10.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "juzaweb/core": "^5.0"
     },
     "require-dev": {
+        "juzaweb/api": "dev-master",
         "orchestra/testbench": "^8.0|^9.0",
         "phpunit/phpunit": "^10.0"
     },

--- a/src/Http/Controllers/API/SupportTicketController.php
+++ b/src/Http/Controllers/API/SupportTicketController.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Juzaweb\Modules\SupportTicket\Http\Controllers\API;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Juzaweb\Modules\Core\Http\Controllers\APIController;
+use Juzaweb\Modules\SupportTicket\Http\Requests\API\StoreSupportTicketRequest;
+use Juzaweb\Modules\SupportTicket\Http\Requests\API\StoreSupportTicketReplyRequest;
+use Juzaweb\Modules\SupportTicket\Http\Resources\API\SupportTicketResource;
+use Juzaweb\Modules\SupportTicket\Http\Resources\API\SupportTicketReplyResource;
+use Juzaweb\Modules\SupportTicket\Models\SupportTicket;
+use Juzaweb\Modules\SupportTicket\Models\SupportTicketReply;
+use OpenApi\Annotations as OA;
+
+class SupportTicketController extends APIController
+{
+    /**
+     * @OA\Get(
+     *      path="/api/v1/support-tickets",
+     *      tags={"Support Ticket"},
+     *      summary="Get user support tickets",
+     *      description="Returns the authenticated user's support tickets.",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(ref="#/components/parameters/query_limit"),
+     *      @OA\Parameter(ref="#/components/parameters/query_page"),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Successful operation",
+     *          @OA\JsonContent(
+     *              type="object",
+     *              @OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/SupportTicketResource"))
+     *          )
+     *      ),
+     *      @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        $tickets = SupportTicket::ofUser($user)->paginate($this->getLimitRequest());
+
+        return response()->json(
+            SupportTicketResource::collection($tickets)->response()->getData(true)
+        );
+    }
+
+    /**
+     * @OA\Post(
+     *      path="/api/v1/support-tickets",
+     *      tags={"Support Ticket"},
+     *      summary="Create support ticket",
+     *      description="Create a new support ticket.",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\RequestBody(
+     *          required=true,
+     *          @OA\JsonContent(
+     *              required={"subject","content"},
+     *              @OA\Property(property="subject", type="string"),
+     *              @OA\Property(property="content", type="string"),
+     *              @OA\Property(property="category_id", type="integer", nullable=true)
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response=201,
+     *          description="Successful operation",
+     *          @OA\JsonContent(
+     *              type="object",
+     *              @OA\Property(property="data", ref="#/components/schemas/SupportTicketResource")
+     *          )
+     *      ),
+     *      @OA\Response(response=401, description="Unauthorized"),
+     *      @OA\Response(response=422, description="Validation error")
+     * )
+     */
+    public function store(StoreSupportTicketRequest $request): JsonResponse
+    {
+        $user = $request->user();
+
+        $ticket = SupportTicket::create([
+            'subject' => $request->input('subject'),
+            'content' => $request->input('content'),
+            'category_id' => $request->input('category_id'),
+            'ticketable_type' => get_class($user),
+            'ticketable_id' => $user->getKey(),
+            'status' => 'open',
+        ]);
+
+        return response()->json(
+            ['data' => new SupportTicketResource($ticket)],
+            201
+        );
+    }
+
+    /**
+     * @OA\Post(
+     *      path="/api/v1/support-tickets/{id}/reply",
+     *      tags={"Support Ticket"},
+     *      summary="Reply support ticket",
+     *      description="Reply to a support ticket.",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *          name="id",
+     *          in="path",
+     *          required=true,
+     *          @OA\Schema(type="string")
+     *      ),
+     *      @OA\RequestBody(
+     *          required=true,
+     *          @OA\JsonContent(
+     *              required={"content"},
+     *              @OA\Property(property="content", type="string")
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response=201,
+     *          description="Successful operation",
+     *          @OA\JsonContent(
+     *              type="object",
+     *              @OA\Property(property="data", ref="#/components/schemas/SupportTicketReplyResource")
+     *          )
+     *      ),
+     *      @OA\Response(response=401, description="Unauthorized"),
+     *      @OA\Response(response=404, description="Not found"),
+     *      @OA\Response(response=422, description="Validation error")
+     * )
+     */
+    public function reply(StoreSupportTicketReplyRequest $request, string $id): JsonResponse
+    {
+        $user = $request->user();
+
+        $ticket = SupportTicket::ofUser($user)->findOrFail($id);
+
+        $reply = SupportTicketReply::create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $user->getKey(),
+            'content' => $request->input('content'),
+            'is_staff_reply' => false,
+        ]);
+
+        $ticket->update(['status' => 'open']);
+
+        return response()->json(
+            ['data' => new SupportTicketReplyResource($reply)],
+            201
+        );
+    }
+}

--- a/src/Http/Requests/API/StoreSupportTicketReplyRequest.php
+++ b/src/Http/Requests/API/StoreSupportTicketReplyRequest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Juzaweb\Modules\SupportTicket\Http\Requests\API;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreSupportTicketReplyRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'content' => ['required', 'string'],
+        ];
+    }
+}

--- a/src/Http/Requests/API/StoreSupportTicketRequest.php
+++ b/src/Http/Requests/API/StoreSupportTicketRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Juzaweb\Modules\SupportTicket\Http\Requests\API;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreSupportTicketRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'subject' => ['required', 'string', 'max:255'],
+            'content' => ['required', 'string'],
+            'category_id' => ['nullable', 'exists:support_ticket_categories,id'],
+        ];
+    }
+}

--- a/src/Http/Resources/API/SupportTicketReplyResource.php
+++ b/src/Http/Resources/API/SupportTicketReplyResource.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Juzaweb\Modules\SupportTicket\Http\Resources\API;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Schema(
+ *     schema="SupportTicketReplyResource",
+ *     title="SupportTicketReplyResource",
+ *     @OA\Property(property="id", type="string"),
+ *     @OA\Property(property="ticket_id", type="string"),
+ *     @OA\Property(property="content", type="string"),
+ *     @OA\Property(property="is_staff_reply", type="boolean"),
+ *     @OA\Property(property="created_at", type="string"),
+ *     @OA\Property(property="updated_at", type="string")
+ * )
+ */
+class SupportTicketReplyResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->resource->id,
+            'ticket_id' => $this->resource->ticket_id,
+            'content' => $this->resource->content,
+            'is_staff_reply' => $this->resource->is_staff_reply,
+            'created_at' => jw_date_format($this->resource->created_at),
+            'updated_at' => jw_date_format($this->resource->updated_at),
+        ];
+    }
+}

--- a/src/Http/Resources/API/SupportTicketResource.php
+++ b/src/Http/Resources/API/SupportTicketResource.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Juzaweb\Modules\SupportTicket\Http\Resources\API;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Schema(
+ *     schema="SupportTicketResource",
+ *     title="SupportTicketResource",
+ *     @OA\Property(property="id", type="string"),
+ *     @OA\Property(property="subject", type="string"),
+ *     @OA\Property(property="content", type="string"),
+ *     @OA\Property(property="status", type="string"),
+ *     @OA\Property(property="category_id", type="integer"),
+ *     @OA\Property(property="created_at", type="string"),
+ *     @OA\Property(property="updated_at", type="string")
+ * )
+ */
+class SupportTicketResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->resource->id,
+            'subject' => $this->resource->subject,
+            'content' => $this->resource->content,
+            'status' => $this->resource->status,
+            'category_id' => $this->resource->category_id,
+            'created_at' => jw_date_format($this->resource->created_at),
+            'updated_at' => jw_date_format($this->resource->updated_at),
+        ];
+    }
+}

--- a/src/Providers/RouteServiceProvider.php
+++ b/src/Providers/RouteServiceProvider.php
@@ -16,9 +16,8 @@ class RouteServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->routes(function () {
-            // Route::middleware('api')
-            //     ->prefix('api/v1')
-            //     ->group(__DIR__ . '/../routes/api.php');
+            Route::middleware('api')
+                ->group(__DIR__ . '/../routes/api.php');
 
             $adminPrefix = $this->app['config']->get('core.admin_prefix');
 

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
-use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Juzaweb\Modules\SupportTicket\Http\Controllers\API\SupportTicketController;
 
 /*
 |--------------------------------------------------------------------------
@@ -12,3 +13,15 @@ use Illuminate\Http\Request;
 | is assigned the "api" middleware group. Enjoy building your API!
 |
 */
+
+Route::group(
+    [
+        'middleware' => ['auth:api'],
+        'prefix' => 'api/v1',
+    ],
+    function () {
+        Route::get('support-tickets', [SupportTicketController::class, 'index']);
+        Route::post('support-tickets', [SupportTicketController::class, 'store']);
+        Route::post('support-tickets/{id}/reply', [SupportTicketController::class, 'reply']);
+    }
+);


### PR DESCRIPTION
Adds API endpoints for listing, creating, and replying to support tickets for authenticated users. The endpoints are exposed under `/api/v1/support-tickets` and `/api/v1/support-tickets/{id}/reply`, documented with OpenAPI annotations, and validated using form requests.

---
*PR created automatically by Jules for task [13185962561696386994](https://jules.google.com/task/13185962561696386994) started by @juzaweb*