### PR TITLE
feat: Add show API and refactor SupportTicket responses

### DIFF
--- a/src/Http/Controllers/API/SupportTicketController.php
+++ b/src/Http/Controllers/API/SupportTicketController.php
@@ -7,8 +7,6 @@ use Illuminate\Http\Request;
 use Juzaweb\Modules\Core\Http\Controllers\APIController;
 use Juzaweb\Modules\SupportTicket\Http\Requests\API\StoreSupportTicketRequest;
 use Juzaweb\Modules\SupportTicket\Http\Requests\API\StoreSupportTicketReplyRequest;
-use Juzaweb\Modules\SupportTicket\Http\Resources\API\SupportTicketResource;
-use Juzaweb\Modules\SupportTicket\Http\Resources\API\SupportTicketReplyResource;
 use Juzaweb\Modules\SupportTicket\Models\SupportTicket;
 use Juzaweb\Modules\SupportTicket\Models\SupportTicketReply;
 use OpenApi\Annotations as OA;
@@ -41,9 +39,41 @@ class SupportTicketController extends APIController
 
         $tickets = SupportTicket::ofUser($user)->paginate($this->getLimitRequest());
 
-        return response()->json(
-            SupportTicketResource::collection($tickets)->response()->getData(true)
-        );
+        return $this->restSuccess($tickets);
+    }
+
+    /**
+     * @OA\Get(
+     *      path="/api/v1/support-tickets/{id}",
+     *      tags={"Support Ticket"},
+     *      summary="Get a support ticket",
+     *      description="Get a support ticket by id.",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *          name="id",
+     *          in="path",
+     *          required=true,
+     *          @OA\Schema(type="string")
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Successful operation",
+     *          @OA\JsonContent(
+     *              type="object",
+     *              @OA\Property(property="data", ref="#/components/schemas/SupportTicketResource")
+     *          )
+     *      ),
+     *      @OA\Response(response=401, description="Unauthorized"),
+     *      @OA\Response(response=404, description="Not found")
+     * )
+     */
+    public function show(Request $request, string $id): JsonResponse
+    {
+        $user = $request->user();
+
+        $ticket = SupportTicket::ofUser($user)->findOrFail($id);
+
+        return $this->restSuccess($ticket);
     }
 
     /**
@@ -87,10 +117,7 @@ class SupportTicketController extends APIController
             'status' => 'open',
         ]);
 
-        return response()->json(
-            ['data' => new SupportTicketResource($ticket)],
-            201
-        );
+        return $this->restSuccess($ticket, '', 201);
     }
 
     /**
@@ -141,9 +168,6 @@ class SupportTicketController extends APIController
 
         $ticket->update(['status' => 'open']);
 
-        return response()->json(
-            ['data' => new SupportTicketReplyResource($reply)],
-            201
-        );
+        return $this->restSuccess($reply, '', 201);
     }
 }

--- a/src/Models/SupportTicket.php
+++ b/src/Models/SupportTicket.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Juzaweb\Modules\Core\Models\Authenticatable;
 use Juzaweb\Modules\Core\Models\Model;
 use Juzaweb\Modules\Core\Traits\HasAPI;
+use Juzaweb\Modules\SupportTicket\Http\Resources\API\SupportTicketResource;
 
 class SupportTicket extends Model
 {
@@ -49,5 +50,10 @@ class SupportTicket extends Model
     {
         return $builder->where('ticketable_type', get_class($user))
             ->where('ticketable_id', $user->getKey());
+    }
+
+    public static function getResource(): string
+    {
+        return SupportTicketResource::class;
     }
 }

--- a/src/Models/SupportTicketReply.php
+++ b/src/Models/SupportTicketReply.php
@@ -6,10 +6,12 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Juzaweb\Modules\Admin\Models\User;
 use Juzaweb\Modules\Core\Models\Model;
+use Juzaweb\Modules\Core\Traits\HasAPI;
+use Juzaweb\Modules\SupportTicket\Http\Resources\API\SupportTicketReplyResource;
 
 class SupportTicketReply extends Model
 {
-    use HasUuids;
+    use HasAPI, HasUuids;
 
     protected $table = 'support_ticket_replies';
 
@@ -32,5 +34,10 @@ class SupportTicketReply extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public static function getResource(): string
+    {
+        return SupportTicketReplyResource::class;
     }
 }


### PR DESCRIPTION
This PR addresses the user's request to:
1. Add a `show` method to the SupportTicket API.
2. Update the models to use the `getResource()` functionality from the `HasAPI` trait.
3. Refactor the `SupportTicketController` to use `$this->restSuccess(...)` instead of manually formatting the JSON responses with the resource collection.

### Changes Made:
- **`src/Models/SupportTicket.php`**: Implemented `getResource()` returning `SupportTicketResource::class`.
- **`src/Models/SupportTicketReply.php`**: Added the `HasAPI` trait and implemented `getResource()` returning `SupportTicketReplyResource::class`.
- **`src/Http/Controllers/API/SupportTicketController.php`**:
  - Added the `show` method with OpenAPI documentation to fetch a ticket by ID, restricted by the user scope.
  - Refactored `index`, `store`, and `reply` methods to return `$this->restSuccess(...)`.
  - Cleaned up unused resource imports.

---
*PR created automatically by Jules for task [10552282705103129692](https://jules.google.com/task/10552282705103129692) started by @juzaweb*