### PR TITLE
feat: Add API endpoint to get support ticket replies

### DIFF
--- a/src/Http/Controllers/API/SupportTicketController.php
+++ b/src/Http/Controllers/API/SupportTicketController.php
@@ -77,6 +77,43 @@ class SupportTicketController extends APIController
     }
 
     /**
+     * @OA\Get(
+     *      path="/api/v1/support-tickets/{id}/replies",
+     *      tags={"Support Ticket"},
+     *      summary="Get support ticket replies",
+     *      description="Get replies for a specific support ticket.",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *          name="id",
+     *          in="path",
+     *          required=true,
+     *          @OA\Schema(type="string")
+     *      ),
+     *      @OA\Parameter(ref="#/components/parameters/query_limit"),
+     *      @OA\Parameter(ref="#/components/parameters/query_page"),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Successful operation",
+     *          @OA\JsonContent(
+     *              type="object",
+     *              @OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/SupportTicketReplyResource"))
+     *          )
+     *      ),
+     *      @OA\Response(response=401, description="Unauthorized"),
+     *      @OA\Response(response=404, description="Not found")
+     * )
+     */
+    public function replies(Request $request, string $id): JsonResponse
+    {
+        $user = $request->user();
+
+        $ticket = SupportTicket::ofUser($user)->findOrFail($id);
+        $replies = $ticket->replies()->paginate($this->getLimitRequest());
+
+        return $this->restSuccess($replies);
+    }
+
+    /**
      * @OA\Post(
      *      path="/api/v1/support-tickets",
      *      tags={"Support Ticket"},

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -21,6 +21,8 @@ Route::group(
     ],
     function () {
         Route::get('support-tickets', [SupportTicketController::class, 'index']);
+        Route::get('support-tickets/{id}', [SupportTicketController::class, 'show']);
+        Route::get('support-tickets/{id}/replies', [SupportTicketController::class, 'replies']);
         Route::post('support-tickets', [SupportTicketController::class, 'store']);
         Route::post('support-tickets/{id}/reply', [SupportTicketController::class, 'reply']);
     }


### PR DESCRIPTION
Adds a new API endpoint `/api/v1/support-tickets/{id}/replies` to retrieve the replies for a specific support ticket. Also registers the existing `show` method under `/api/v1/support-tickets/{id}`.

---
*PR created automatically by Jules for task [2319049543269197850](https://jules.google.com/task/2319049543269197850) started by @juzaweb*